### PR TITLE
Moved RUN command into a build script to save ~850 MB from the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,30 +2,15 @@ FROM centos:centos7
 
 MAINTAINER Tomohisa Kusano <siomiz@gmail.com>
 
-RUN yum -y update \
-	&& yum -y groupinstall "Development Tools" \
-	&& yum -y install readline-devel ncurses-devel openssl-devel
+COPY build.sh /build.sh
+RUN chmod +x /build.sh \
+    && /build.sh \
+    && rm /build.sh
 
-RUN git clone https://github.com/SoftEtherVPN/SoftEtherVPN.git /usr/local/src/vpnserver
-
-WORKDIR /usr/local/src/vpnserver
-
-RUN cp src/makefiles/linux_64bit.mak Makefile
-RUN make
-
-RUN cp bin/vpnserver/vpnserver /opt/vpnserver
-RUN cp bin/vpnserver/hamcore.se2 /opt/hamcore.se2
-RUN cp bin/vpncmd/vpncmd /opt/vpncmd
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 WORKDIR /opt
-RUN rm -rf /usr/local/src/vpnserver
-
-RUN yum -y remove readline-devel ncurses-devel openssl-devel \
-	&& yum -y groupremove "Development Tools" \
-	&& yum clean all
-
-ADD entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+yum -y update \
+  && yum -y groupinstall "Development Tools" \
+  && yum -y install readline-devel ncurses-devel openssl-devel
+
+git clone https://github.com/SoftEtherVPN/SoftEtherVPN.git /usr/local/src/vpnserver
+
+cd /usr/local/src/vpnserver
+
+cp src/makefiles/linux_64bit.mak Makefile
+make
+
+cp bin/vpnserver/vpnserver /opt/vpnserver
+cp bin/vpnserver/hamcore.se2 /opt/hamcore.se2
+cp bin/vpncmd/vpncmd /opt/vpncmd
+
+rm -rf /usr/local/src/vpnserver
+
+yum -y remove readline-devel ncurses-devel openssl-devel \
+  && yum -y groupremove "Development Tools" \
+  && yum clean all
+
+exit 0


### PR DESCRIPTION
Building softether and doing all the other RUN steps inside a single RUN statement will save a lot of space.

```
REPOSITORY                    TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
ianneub/softether             latest              d6b80c99fdc3        2 minutes ago       376.9 MB
siomiz/softethervpn           latest              969965c841d4        5 days ago          1.246 GB
```