### PR TITLE
LogDisable to reduce write

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,6 +39,10 @@ done
 # enable SecureNAT
 /opt/vpncmd localhost /SERVER /CSV /HUB:DEFAULT /CMD SecureNatEnable
 
+# disable extra logs
+/opt/vpncmd localhost /SERVER /CSV /HUB:DEFAULT /CMD LogDisable packet
+/opt/vpncmd localhost /SERVER /CSV /HUB:DEFAULT /CMD LogDisable security
+
 # add user
 /opt/vpncmd localhost /SERVER /HUB:DEFAULT /CSV /CMD UserCreate ${USERNAME} /GROUP:none /REALNAME:none /NOTE:none
 /opt/vpncmd localhost /SERVER /HUB:DEFAULT /CSV /CMD UserPasswordSet ${USERNAME} /PASSWORD:${PASSWORD}


### PR DESCRIPTION
security logs are redundant with server logs.
packet logs are filled with "The VPN Server is either Open-Source or Free version. It hasn't implemented the IP Address or TCP/UDP header data logging function. No IP address nor TCP/UDP header data are not be recorded here."