### PR TITLE
Expose logging directory via a volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,15 @@ RUN wget https://github.com/SoftEtherVPN/SoftEtherVPN_Stable/archive/v${BUILD_VE
     && apt-get -y autoremove && rm -rf /var/lib/apt/lists/*
 
 COPY copyables /
+
 RUN chmod +x /entrypoint.sh /gencert.sh \
     && rm -rf /opt && ln -s /usr/vpnserver /opt \
     && find /usr/bin/vpn* -type f ! -name vpnserver \
        -exec bash -c 'ln -s {} /opt/$(basename {})' \;
 
 WORKDIR /usr/vpnserver/
+
+VOLUME ["/usr/vpnserver/server_log/"]
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Travis](https://img.shields.io/travis/siomiz/SoftEtherVPN/master.svg?style=flat-square)](https://travis-ci.org/siomiz/SoftEtherVPN)
 
-**Note:** OpenVPN support is enabled on :latest image. STDOUT (`docker log`) format has changed as a result.
+**Note:** Base image is switched to debian:9-slim; please file issues if this is a problem for you.
 
 ## Setup
  - L2TP/IPSec PSK + OpenVPN
  - SecureNAT enabled
  - Perfect Forward Secrecy (DHE-RSA-AES256-SHA)
- - make'd from [the official SoftEther VPN GitHub Stable Edition Repository][2] **v4.22-9634-beta** (pinned until #33 is resolved).
+ - make'd from [the official SoftEther VPN GitHub Stable Edition Repository][2] **v4.25-9656-rtm**.
 
 `docker run -d --cap-add NET_ADMIN -p 500:500/udp -p 4500:4500/udp -p 1701:1701/tcp -p 1194:1194/udp -p 5555:5555/tcp siomiz/softethervpn`
 


### PR DESCRIPTION
At the moment, soft ether is logging directly into the container. Ideally, we'd make it log to stdout so the logs would be accessible through `docker container logs`. But that's a bit tricky since there doesn't seem to be a way of  turning soft ether's system log rotation off. With log rotation, we can't easily link the log file to stdout. That's why I suggest, for now, exposing the system_log directory as a volume.